### PR TITLE
Add run-once exit option and fix Ring API compatibility

### DIFF
--- a/Api/Exceptions/AuthenticationFailedException.cs
+++ b/Api/Exceptions/AuthenticationFailedException.cs
@@ -11,6 +11,10 @@ namespace KoenZomers.Ring.Api.Exceptions
         {
         }
 
+        public AuthenticationFailedException(string message) : base(message)
+        {
+        }
+
         public AuthenticationFailedException(Exception innerException) : base("Authentication of the session failed", innerException)
         {
         }

--- a/Api/HttpUtility.cs
+++ b/Api/HttpUtility.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -72,7 +72,7 @@ namespace KoenZomers.Ring.Api
         /// <param name="bearerToken">Bearer token to authenticate the request with. Leave out to not authenticate the session.</param>
         /// <returns>Contents of the result returned by the webserver</returns>
         /// <exception cref="Exceptions.ThrottledException">Thrown when the web server indicates too many requests have been made (HTTP 429).</exception>
-        public async Task<string> GetContents(Uri url, string bearerToken = null)
+        public async Task<string> GetContents(Uri url, string bearerToken = null, string hardwareId = null)
         {
             // Construct the request
             var request = new HttpRequestMessage
@@ -85,6 +85,13 @@ namespace KoenZomers.Ring.Api
             if (!string.IsNullOrEmpty(bearerToken))
             {
                 request.Headers.Add(HttpRequestHeader.Authorization.ToString(), $"Bearer {bearerToken}");
+            }
+
+            request.Headers.TryAddWithoutValidation("User-Agent", "android:com.ringapp");
+
+            if (!string.IsNullOrEmpty(hardwareId))
+            {
+                request.Headers.Add("hardware_id", hardwareId);
             }
 
             // Send the request to the webserver
@@ -101,7 +108,107 @@ namespace KoenZomers.Ring.Api
 
             // Return the response from the server
             var responseFromServer = await response.Content.ReadAsStringAsync();
+
             return responseFromServer;
+        }
+
+        /// <summary>
+        /// Sends a POST request for OAuth authentication with Basic Auth credentials
+        /// </summary>
+        /// <param name="url">Url to POST to</param>
+        /// <param name="formFields">Dictionary with key/value pairs to send as form-encoded body</param>
+        /// <param name="headerFields">NameValueCollection with the fields to add to the header sent to the server with the request</param>
+        /// <returns>The website contents returned by the webserver after posting the data</returns>
+        /// <exception cref="Exceptions.ThrottledException">Thrown when the web server indicates too many requests have been made (HTTP 429).</exception>
+        /// <exception cref="Exceptions.TwoFactorAuthenticationIncorrectException">Thrown when the web server indicates the two-factor code was incorrect (HTTP 400).</exception>
+        /// <exception cref="Exceptions.TwoFactorAuthenticationRequiredException">Thrown when the web server indicates two-factor authentication is required (HTTP 412).</exception>
+        public async Task<string> OAuthPost(Uri url, Dictionary<string, string> formFields, NameValueCollection headerFields)
+        {
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = url
+            };
+
+            if (headerFields != null)
+            {
+                foreach (string headerField in headerFields)
+                {
+                    request.Headers.Add(headerField, headerFields[headerField]);
+                }
+            }
+
+            request.Headers.TryAddWithoutValidation("User-Agent", "android:com.ringapp");
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            var json = JsonSerializer.Serialize(formFields);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.SendAsync(request);
+
+            if (response == null) return null;
+
+            var responseText = await response.Content.ReadAsStringAsync();
+
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.BadRequest:
+                    if (responseText.Contains("Too many requests", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        throw new Exceptions.ThrottledException();
+                    }
+                    if (responseText.Contains("Verification Code is invalid or expired", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        throw new Exceptions.TwoFactorAuthenticationIncorrectException();
+                    }
+                    break;
+
+                case HttpStatusCode.PreconditionFailed:
+                    throw new Exceptions.TwoFactorAuthenticationRequiredException();
+
+                case HttpStatusCode.Unauthorized:
+                    throw new Exceptions.AuthenticationFailedException();
+
+                default:
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        throw new Exceptions.AuthenticationFailedException($"Ring API returned HTTP {(int)response.StatusCode} ({response.StatusCode}): {responseText}");
+                    }
+                    break;
+            }
+
+            if (responseText == null) return null;
+            return responseText;
+        }
+
+        /// <summary>
+        /// Sends a POST request with a raw JSON body string
+        /// </summary>
+        public async Task<string> JsonPostRaw(Uri url, string jsonBody, NameValueCollection headerFields)
+        {
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = url
+            };
+
+            if (headerFields != null)
+            {
+                foreach (string headerField in headerFields)
+                {
+                    request.Headers.TryAddWithoutValidation(headerField, headerFields[headerField]);
+                }
+            }
+
+            request.Headers.TryAddWithoutValidation("User-Agent", "android:com.ringapp");
+
+            request.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.SendAsync(request);
+            if (response == null) return null;
+
+            var responseText = await response.Content.ReadAsStringAsync();
+            return responseText;
         }
 
         /// <summary>
@@ -132,7 +239,10 @@ namespace KoenZomers.Ring.Api
             }
 
             // Always add the User-Agent header
-            request.Headers.UserAgent.TryParseAdd("android:com.ringapp");
+            request.Headers.TryAddWithoutValidation("User-Agent", "android:com.ringapp");
+
+            // Add Accept header for JSON responses
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             // Set the content for the HTTP request
             request.Content = new FormUrlEncodedContent(formFields);
@@ -168,6 +278,13 @@ namespace KoenZomers.Ring.Api
 
                 case HttpStatusCode.Unauthorized:
                     throw new Exceptions.AuthenticationFailedException();
+
+                default:
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        throw new Exceptions.AuthenticationFailedException($"Ring API returned HTTP {(int)response.StatusCode} ({response.StatusCode}): {responseText}");
+                    }
+                    break;
             }
 
             // Make sure the response content is available

--- a/Api/Session.cs
+++ b/Api/Session.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -14,6 +14,36 @@ namespace KoenZomers.Ring.Api
     public class Session
     {
         #region Properties
+
+        /// <summary>
+        /// Stable hardware ID generated for this machine to avoid duplicate auth entries.
+        /// Persisted to disk so it remains consistent across sessions.
+        /// </summary>
+        private static readonly string _hardwareId = GetOrCreateHardwareId();
+
+        private static string GetOrCreateHardwareId()
+        {
+            var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "RingVideosData");
+            var filePath = Path.Combine(folder, "hardware_id.txt");
+            try
+            {
+                if (File.Exists(filePath))
+                {
+                    var id = File.ReadAllText(filePath).Trim();
+                    if (!string.IsNullOrEmpty(id)) return id;
+                }
+            }
+            catch { }
+
+            var newId = Guid.NewGuid().ToString();
+            try
+            {
+                if (!Directory.Exists(folder)) Directory.CreateDirectory(folder);
+                File.WriteAllText(filePath, newId);
+            }
+            catch { }
+            return newId;
+        }
 
         /// <summary>
         /// Username to use to connect to the Ring API. Set by providing it in the constructor.
@@ -127,7 +157,7 @@ namespace KoenZomers.Ring.Api
         /// <exception cref="Exceptions.TwoFactorAuthenticationIncorrectException">Thrown when the web server indicates the two-factor code was incorrect (HTTP 400).</exception>
         /// <exception cref="Exceptions.TwoFactorAuthenticationRequiredException">Thrown when the web server indicates two-factor authentication is required (HTTP 412).</exception>
         public async Task<Entities.Session> Authenticate(   string operatingSystem = "windows", 
-                                                            string hardwareId = "unspecified", 
+                                                            string hardwareId = null, 
                                                             string appBrand = "ring", 
                                                             string deviceModel = "unspecified", 
                                                             string deviceName = "unspecified", 
@@ -148,7 +178,7 @@ namespace KoenZomers.Ring.Api
 
             if (string.IsNullOrEmpty(hardwareId))
             {
-                throw new ArgumentNullException("hardwareId", "HardwareId system is mandatory");
+                hardwareId = _hardwareId;
             }
 
             // Construct the Form POST fields to send along with the authentication request
@@ -164,16 +194,16 @@ namespace KoenZomers.Ring.Api
             // If a two factor auth code has been provided, add the code through the HTTP POST header
             var headerFields = new NameValueCollection(capacity: 3) 
             {
-                { "hardware_id", hardwareId }
+                { "hardware_id", hardwareId },
+                { "2fa-support", "true" }
             };
             if (twoFactorAuthCode != null)
             {
-                headerFields.Add("2fa-support", "true");
-                headerFields.Add("2fa-code", twoFactorAuthCode);
+                headerFields["2fa-code"] = twoFactorAuthCode;
             }
 
-            // Make the Form POST request to request an OAuth Token
-            var oAuthResponse = await _httpUtility.FormPost( RingApiOAuthUrl,
+            // Make the OAuth POST request to request an OAuth Token
+            var oAuthResponse = await _httpUtility.OAuthPost( RingApiOAuthUrl,
                                                             oAuthformFields,
                                                             headerFields);
 
@@ -181,39 +211,41 @@ namespace KoenZomers.Ring.Api
             // Deserialize the JSON result into a typed object
             OAuthToken = JsonSerializer.Deserialize<OAutToken>(oAuthResponse);
 
-            // Construct the Form POST fields to send along with the session request
-            var sessionFormFields = new Dictionary<string, string>
+            // Create an API session using JSON (matching Ring's current API requirements)
+            await CreateSession();
+
+            return null;
+        }
+
+        /// <summary>
+        /// Creates an API session with Ring using the current OAuth token
+        /// </summary>
+        private async Task CreateSession()
+        {
+            var sessionData = new
             {
-                { "device[os]", System.Net.WebUtility.UrlEncode(operatingSystem) },
-                { "device[hardware_id]", System.Net.WebUtility.UrlEncode(hardwareId) }
+                device = new
+                {
+                    hardware_id = _hardwareId,
+                    metadata = new
+                    {
+                        api_version = "11",
+                        device_model = "ring-doorbell"
+                    },
+                    os = "android"
+                }
             };
 
-            // Add optional fields if they have been provided
-            if (!string.IsNullOrEmpty(appBrand)) sessionFormFields.Add("device[app_brand]", System.Net.WebUtility.UrlEncode(appBrand));
-            if (!string.IsNullOrEmpty(deviceModel)) sessionFormFields.Add("device[metadata][device_model]", System.Net.WebUtility.UrlEncode(deviceModel));
-            if (!string.IsNullOrEmpty(deviceName)) sessionFormFields.Add("device[metadata][device_name]", System.Net.WebUtility.UrlEncode(deviceName));
-            if (!string.IsNullOrEmpty(resolution)) sessionFormFields.Add("device[metadata][resolution]", System.Net.WebUtility.UrlEncode(resolution));
-            if (!string.IsNullOrEmpty(appVersion)) sessionFormFields.Add("device[metadata][app_version]", System.Net.WebUtility.UrlEncode(appVersion));
-            if (appInstallationDate.HasValue) sessionFormFields.Add("device[metadata][app_instalation_date]", string.Format("{0:yyyy-MM-dd}+{0:HH}%3A{0:mm}%3A{0:ss}Z", appInstallationDate.Value));
-            if (!string.IsNullOrEmpty(manufacturer)) sessionFormFields.Add("device[metadata][manufacturer]", System.Net.WebUtility.UrlEncode(manufacturer));
-            if (!string.IsNullOrEmpty(deviceType)) sessionFormFields.Add("device[metadata][device_type]", System.Net.WebUtility.UrlEncode(deviceType));
-            if (!string.IsNullOrEmpty(architecture)) sessionFormFields.Add("device[metadata][architecture]", System.Net.WebUtility.UrlEncode(architecture));
-            if (!string.IsNullOrEmpty(language)) sessionFormFields.Add("device[metadata][language]", System.Net.WebUtility.UrlEncode(language));
+            var json = JsonSerializer.Serialize(sessionData);
+            var headerFields = new NameValueCollection
+            {
+                { "Accept-Encoding", "gzip, deflate" },
+                { "X-API-LANG", "en" },
+                { "Authorization", $"Bearer {OAuthToken.AccessToken}" },
+                { "hardware_id", _hardwareId }
+            };
 
-            // Make the Form POST request to authenticate
-            var sessionResponse = await _httpUtility.FormPost(   new Uri(RingApiBaseUrl, "session"),
-                                                                sessionFormFields,
-                                                                new System.Collections.Specialized.NameValueCollection
-                                                                {
-                                                                    { "Accept-Encoding", "gzip, deflate" },
-                                                                    { "X-API-LANG", "en" },
-                                                                    { "Authorization", $"Bearer {OAuthToken.AccessToken}" }
-                                                                });
-
-            // Deserialize the JSON result into a typed object
-            var session = JsonSerializer.Deserialize<Entities.Session>(sessionResponse);
-
-            return session;
+            var response = await _httpUtility.JsonPostRaw(new Uri(RingApiBaseUrl, "session"), json, headerFields);
         }
 
         /// <summary>
@@ -245,23 +277,29 @@ namespace KoenZomers.Ring.Api
             var oAuthformFields = new Dictionary<string, string>
             {
                 { "grant_type", "refresh_token" },
-                { "refresh_token", refreshToken }
+                { "refresh_token", refreshToken },
+                { "client_id", "ring_official_android" },
+                { "scope", "client" }
             };
 
             var headerFields = new NameValueCollection()
             { 
-                { "hardware_id", "unspecified" }
+                { "hardware_id", _hardwareId },
+                { "2fa-support", "true" }
             };
-            // Make the Form POST request to request an OAuth Token
+            // Make the OAuth POST request to request an OAuth Token
             try
             {
-                var oAuthResponse = await _httpUtility.FormPost(RingApiOAuthUrl,
+                var oAuthResponse = await _httpUtility.OAuthPost(RingApiOAuthUrl,
                                                                 oAuthformFields,
                                                                 headerFields);
 
 
                 // Deserialize the JSON result into a typed object
                 OAuthToken = JsonSerializer.Deserialize<OAutToken>(oAuthResponse);
+
+                // Create an API session after refreshing the OAuth token
+                await CreateSession();
             }
             catch(System.Net.WebException e)
             {
@@ -324,7 +362,7 @@ namespace KoenZomers.Ring.Api
         {
             await EnsureSessionValid();
 
-            var response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"ring_devices"), AuthenticationToken);
+            var response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"ring_devices?api_version=11"), AuthenticationToken, _hardwareId);
             
             var devices = JsonSerializer.Deserialize<Devices>(response);
             return devices;
@@ -347,7 +385,7 @@ namespace KoenZomers.Ring.Api
             await EnsureSessionValid();
 
             // Receive the first batch
-            var response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"doorbots/{(doorbotId.HasValue ? $"{doorbotId.Value}/" : "")}history{(limit.HasValue ? $"?limit={limit}" : "")}"), AuthenticationToken);
+            var response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"doorbots/{(doorbotId.HasValue ? $"{doorbotId.Value}/" : "")}history{(limit.HasValue ? $"?limit={limit}" : "")}"), AuthenticationToken, _hardwareId);
 
             // Parse the result
             var doorbotHistory = JsonSerializer.Deserialize<List<DoorbotHistoryEvent>>(response);
@@ -367,7 +405,7 @@ namespace KoenZomers.Ring.Api
             do
             {
                 // Retrieve the next batch
-                response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"doorbots/{(doorbotId.HasValue ? $"{doorbotId.Value}/" : "")}history?limit={remainingItems}&older_than={allHistory.Last().Id}"), AuthenticationToken);
+                response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"doorbots/{(doorbotId.HasValue ? $"{doorbotId.Value}/" : "")}history?limit={remainingItems}&older_than={allHistory.Last().Id}"), AuthenticationToken, _hardwareId);
 
                 // Parse the result
                 doorbotHistory = JsonSerializer.Deserialize<List<DoorbotHistoryEvent>>(response);
@@ -427,7 +465,7 @@ namespace KoenZomers.Ring.Api
             do
             {
                 // Retrieve a batch with historical items
-                var response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"doorbots/{(doorbotId.HasValue ? $"{doorbotId.Value}/" : "")}history?limit={batchWithItems}{(doorbotHistory.Count == 0 ? "" : "&older_than=" + doorbotHistory.Last().Id)}"), AuthenticationToken);
+                var response = await _httpUtility.GetContents(new Uri(RingApiBaseUrl, $"doorbots/{(doorbotId.HasValue ? $"{doorbotId.Value}/" : "")}history?limit={batchWithItems}{(doorbotHistory.Count == 0 ? "" : "&older_than=" + doorbotHistory.Last().Id)}"), AuthenticationToken, _hardwareId);
 
                 // Parse the result
                 doorbotHistory = JsonSerializer.Deserialize<List<DoorbotHistoryEvent>>(response);
@@ -490,7 +528,7 @@ namespace KoenZomers.Ring.Api
             for(var downloadAttempt = 1; downloadAttempt < 60; downloadAttempt++)
             {
                 // Request to download the recording
-                var response = await _httpUtility.GetContents(downloadRequestUri, AuthenticationToken);
+                var response = await _httpUtility.GetContents(downloadRequestUri, AuthenticationToken, _hardwareId);
 
                 // Parse the result
                 downloadResult = JsonSerializer.Deserialize<DownloadRecording>(response);
@@ -606,7 +644,7 @@ namespace KoenZomers.Ring.Api
             for (var downloadAttempt = 1; downloadAttempt < 60; downloadAttempt++)
             {
                 // Request to share the recording
-                var response = await _httpUtility.GetContents(downloadRequestUri, AuthenticationToken);
+                var response = await _httpUtility.GetContents(downloadRequestUri, AuthenticationToken, _hardwareId);
 
                 // Parse the result
                 shareResult = JsonSerializer.Deserialize<SharedRecording>(response);

--- a/RingVideos/CommandHelper.cs
+++ b/RingVideos/CommandHelper.cs
@@ -95,7 +95,6 @@ namespace RingVideos
          rootCommand.Add(snapshotCommand);
          rootCommand.Add(showLogCommand);
          rootCommand.Add(deviceListCommand);
-         rootCommand.Add(exitAppOption);
          rootCommand.Add(quitCommand);
 
          starCommand.Add(userNameOption);
@@ -105,6 +104,7 @@ namespace RingVideos
          starCommand.Add(endOption);
          starCommand.Add(maxcountOption);
          starCommand.Add(deviceIdOption);
+         starCommand.Add(exitAppOption);
 
          allCommand.Add(userNameOption);
          allCommand.Add(passwordOption);
@@ -113,6 +113,7 @@ namespace RingVideos
          allCommand.Add(endOption);
          allCommand.Add(maxcountOption);
          allCommand.Add(deviceIdOption);
+         allCommand.Add(exitAppOption);
 
          snapshotCommand.Add(userNameOption);
          snapshotCommand.Add(passwordOption);
@@ -120,6 +121,9 @@ namespace RingVideos
          snapshotCommand.Add(startOption);
          snapshotCommand.Add(endOption);
          snapshotCommand.Add(deviceIdOption);
+         snapshotCommand.Add(exitAppOption);
+
+         deviceListCommand.Add(exitAppOption);
 
          return rootCommand;
       }

--- a/RingVideos/RingVideoApplication.cs
+++ b/RingVideos/RingVideoApplication.cs
@@ -233,11 +233,12 @@ namespace RingVideos
             int failedCount = 0;
             List<(bool success, eNt.DoorbotHistoryEvent ding)> results = new();
             this.ringSession = await Authenicate();
-            this.Auth.ClearTextRefreshToken = this.ringSession.OAuthToken.RefreshToken;
             if (this.ringSession == null || !this.ringSession.IsAuthenticated)
             {
+               cw.Error("Authentication failed. Please check your credentials.");
                return 999;
             }
+            this.Auth.ClearTextRefreshToken = this.ringSession.OAuthToken.RefreshToken;
 
             if (Filter.DownloadPath == null)
             {
@@ -507,8 +508,16 @@ namespace RingVideos
       {
          if (this.ringSession == null)
          {
-            this.Auth.UserName = username;
-            this.Auth.ClearTextPassword = password;
+            if (!string.IsNullOrEmpty(username))
+            {
+               this.Auth.UserName = username;
+            }
+            if (!string.IsNullOrEmpty(password))
+            {
+               this.Auth.ClearTextPassword = password;
+               this.Auth.ClearTextRefreshToken = "";
+               this.Auth.RefreshToken = "";
+            }
             this.ringSession = await Authenicate();
          }
 

--- a/RingVideos/Worker.cs
+++ b/RingVideos/Worker.cs
@@ -29,8 +29,9 @@ namespace RingVideos
       private static CommandHelper cmdHelper;
       private static RootCommand rootCommand;
       private static ConsoleWriter cw;
+      private static IHostApplicationLifetime appLifetime;
 
-      public Worker(ILogger<Worker> log, IConfiguration config, RingVideoApplication ringApp,  StartArgs sArgs, CommandHelper cmdHelper, ConsoleWriter  consoleWriter)
+      public Worker(ILogger<Worker> log, IConfiguration config, RingVideoApplication ringApp,  StartArgs sArgs, CommandHelper cmdHelper, ConsoleWriter  consoleWriter, IHostApplicationLifetime appLifetime)
       {
          Worker.log = log;
          Worker.ringApp = ringApp;
@@ -38,6 +39,7 @@ namespace RingVideos
          Worker.config = config;
          Worker.cmdHelper = cmdHelper;
          Worker.cw = consoleWriter;
+         Worker.appLifetime = appLifetime;
 
       }
       protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -60,7 +62,8 @@ namespace RingVideos
             //}
             if (Worker.sArgs.Args.Contains("-x") || Worker.sArgs.Args.Contains("--exit"))
             {
-               Environment.Exit(val);
+               appLifetime.StopApplication();
+               return;
             }
             showFilter = false;
             while (true)
@@ -185,7 +188,7 @@ namespace RingVideos
      
       public static void QuitApplication()
       {
-         Environment.Exit(0);
+         appLifetime.StopApplication();
       }
       private static bool SetAuthenticationValues()
       {


### PR DESCRIPTION
- Move -x/--exit option to subcommands (all, starred, snapshot, devices) so it works with commands like 'all --start 4/8/2026 -x'
- Use IHostApplicationLifetime for graceful shutdown instead of Environment.Exit()

Ring API fixes:
- Switch OAuth requests to JSON body with proper headers (fixes HTTP 406)
- Add hardware_id header to all API requests (required for device listing)
- Add 2fa-support header on all auth requests
- Create API session (POST /clients_api/session) after token refresh, not just after initial password auth
- Fix User-Agent header using TryAddWithoutValidation (colon in 'android:com.ringapp' caused silent TryParseAdd failure)
- Persist hardware_id to disk so it remains stable across sessions
- Add OAuthPost and JsonPostRaw methods to HttpUtility
- Add non-success status code handling in FormPost (catch-all for unexpected HTTP errors)
- Add message constructor to AuthenticationFailedException

Bug fixes:
- Fix null reference in RingVideoApplication.Run() by checking ringSession before accessing OAuthToken
- Clear saved refresh token when new credentials are provided so the app doesn't reuse a stale token from a different account