### PR TITLE
Add event filters, upgrade to .NET 10, and fix REPL/quit bugs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.x
+        dotnet-version: 10.x
      
     - name: Restore dependencies
       run: dotnet restore
@@ -29,10 +29,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ringvideos
-        path: "./RingVideos/bin/Release/net8.0/win-x64/publish"
+        path: "./RingVideos/bin/Release/net10.0/win-x64/publish"
 
     - name: Zip Windows files 
-      run: Compress-Archive -Path ./RingVideos/bin/Release/net8.0/win-x64/publish -DestinationPath ./ringvideos.zip
+      run: Compress-Archive -Path ./RingVideos/bin/Release/net10.0/win-x64/publish -DestinationPath ./ringvideos.zip
 
     # Windows ARM    
     - name: Publish for Windows ARM
@@ -42,10 +42,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ringvideos-arm64
-        path: "./RingVideos/bin/Release/net8.0/win-arm64/publish"
+        path: "./RingVideos/bin/Release/net10.0/win-arm64/publish"
 
     - name: Zip Windows files 
-      run: Compress-Archive -Path ./RingVideos/bin/Release/net8.0/win-arm64/publish -DestinationPath ./ringvideos-arm64.zip
+      run: Compress-Archive -Path ./RingVideos/bin/Release/net10.0/win-arm64/publish -DestinationPath ./ringvideos-arm64.zip
         
     #Linux x64    
     - name: Publish for Linux
@@ -55,10 +55,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ringvideos-linux-x64
-        path: "./RingVideos/bin/Release/net8.0/linux-x64/publish"
+        path: "./RingVideos/bin/Release/net10.0/linux-x64/publish"
 
     - name: Zip Linux x64 files 
-      run: Compress-Archive -Path ./RingVideos/bin/Release/net8.0/linux-x64/publish -DestinationPath ./ringvideos-linux-x64.zip
+      run: Compress-Archive -Path ./RingVideos/bin/Release/net10.0/linux-x64/publish -DestinationPath ./ringvideos-linux-x64.zip
 
      #OSX ARM    
     - name: Publish for OSX ARM
@@ -68,10 +68,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ringvideos-osx-arm
-        path: "./RingVideos/bin/Release/net8.0/osx-arm64/publish"
+        path: "./RingVideos/bin/Release/net10.0/osx-arm64/publish"
 
     - name: Zip OSX ARM files 
-      run: Compress-Archive -Path ./RingVideos/bin/Release/net8.0/osx-arm64/publish -DestinationPath ./ringvideos-osx-arm.zip
+      run: Compress-Archive -Path ./RingVideos/bin/Release/net10.0/osx-arm64/publish -DestinationPath ./ringvideos-osx-arm.zip
 
     #OSX x64 
     - name: Publish for OSX x64
@@ -81,10 +81,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ringvideos-osx-x64
-        path: "./RingVideos/bin/Release/net8.0/osx-x64/publish"
+        path: "./RingVideos/bin/Release/net10.0/osx-x64/publish"
 
     - name: Zip OSX x64 files
-      run: Compress-Archive -Path ./RingVideos/bin/Release/net8.0/osx-x64/publish -DestinationPath ./ringvideos-osx-x64.zip
+      run: Compress-Archive -Path ./RingVideos/bin/Release/net10.0/osx-x64/publish -DestinationPath ./ringvideos-osx-x64.zip
 
     #Create release    
     - name: Create GitHub Release

--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-       <TargetFramework>net8.0</TargetFramework>
+       <TargetFramework>net10.0</TargetFramework>
         <RootNamespace>KoenZomers.Ring.Api</RootNamespace>
         <!--<SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\KoenZomers.Ring.Api.snk</AssemblyOriginatorKeyFile>-->

--- a/Api/Entities/CvProperties.cs
+++ b/Api/Entities/CvProperties.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.Json.Serialization;
+
+namespace KoenZomers.Ring.Api.Entities
+{
+    /// <summary>
+    /// Computer vision properties returned by the Ring API for a history event.
+    /// Indicates whether the Ring backend detected a person (or other classified object) in the recording.
+    /// </summary>
+    public class CvProperties
+    {
+        /// <summary>
+        /// When true, Ring's computer vision detected a person in the recording.
+        /// May be null if the event was not evaluated by CV (e.g. rings, older firmware, etc.).
+        /// </summary>
+        [JsonPropertyName("person_detected")]
+        public bool? PersonDetected { get; set; }
+
+        /// <summary>
+        /// When true, Ring indicated the recording stream was broken / incomplete.
+        /// </summary>
+        [JsonPropertyName("stream_broken")]
+        public bool? StreamBroken { get; set; }
+
+        /// <summary>
+        /// The classified detection type reported by Ring (e.g. "human", "vehicle", "animal", "other_motion").
+        /// </summary>
+        [JsonPropertyName("detection_type")]
+        public string DetectionType { get; set; }
+    }
+}

--- a/Api/Entities/DoorbotHistoryEvent.cs
+++ b/Api/Entities/DoorbotHistoryEvent.cs
@@ -60,5 +60,11 @@ namespace KoenZomers.Ring.Api.Entities
 
         [JsonPropertyName("doorbot")]
         public Doorbot Doorbot { get; set; }
+
+        /// <summary>
+        /// Computer vision properties (person detection, detection type, etc.) for this event, when available.
+        /// </summary>
+        [JsonPropertyName("cv_properties")]
+        public CvProperties CvProperties { get; set; }
     }
 }

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,7 +3,8 @@
 [![Build Status](https://github.com/mmckechney/RingVideos/actions/workflows/dotnet.yml/badge.svg)](https://github.com/mmckechney/RingVideos/actions/workflows/dotnet.yml)
 
 This simple console app (written in .NET Core) will allow you do perform a bulk download of your [Ring.com](https://www.ring.com) videos.
-You can download videos based in a date range and/or if they are starred
+You can filter the videos you download by date range, whether they are starred, the event kind (motion / doorbell ring / live-view / alarm), and by what Ring's computer vision detected in the recording (person, vehicle, animal, etc.).
+
 ## Usage
 
 ```
@@ -21,17 +22,69 @@ Commands:
   starred     Download only starred videos
   all         Download all videos (starred and unstarred)
   snapshot    Download only snapshot images
+  devices     Get list of devices and their ID values
+  showlog     Open the log file
+  quit        Quit/close the application
 
-Options:
-  -u, --username <username>    Ring account username [default: ]
-  -p, --password <password>    Ring account password [default: ]
-  --path <path>                Path to save videos to [default: ]
-  -s, --start <start>          Start time (earliest videos to download) [default: 1/1/0001 12:00:00 AM]
-  -e, --end <end>              End time (latest videos to download) [default: 12/31/9999 11:59:59 PM]
-  -m, --maxcount <maxcount>    Maximum number of videos to download [default: 1000]
-  -?, -h, --help               Show help and usage information
+Options (for `starred` and `all`):
+  -u, --username <username>              Ring account username
+  -p, --password <password>              Ring account password
+  --path <path>                          Path to save videos to
+  -s, --start <start>                    Start time (earliest videos to download) [default: 1/1/0001 12:00:00 AM]
+  -e, --end <end>                        End time (latest videos to download) [default: 12/31/9999 11:59:59 PM]
+  -m, --maxcount <maxcount>              Maximum number of videos to download [default: 1000]
+  --id, --device-id <device-id>          Only download from the specified device (use `devices` to list)
+  -P, --person                           Only download videos where a person was detected (shortcut for `--detection-type human`)
+  -k, --kind <kind>                      Only download events of this kind: `motion`, `ding`, `on_demand`, `alarm`
+  -D, --detection-type <type>            Only download events where Ring CV classified the detection as this type.
+                                         Common values: `human`, `vehicle`, `animal`, `package`, `other_motion`
+  -x, --exit                             Close the app after running the command (useful for scripting)
+  -?, -h, --help                         Show help and usage information
 ```
 
+### Filter reference
+
+The following filters can be combined (they are AND-ed together):
+
+| Flag | Effect |
+| --- | --- |
+| `-s` / `--start`, `-e` / `--end` | Restrict to events in a date range. |
+| `-m` / `--maxcount` | Cap the total number of videos downloaded. |
+| `--id` / `--device-id` | Restrict to a specific camera/doorbell. |
+| `starred` (command) | Only events you starred/favorited in the Ring app. |
+| `-P` / `--person` | Only events where Ring CV detected a person. |
+| `-k` / `--kind` | Only events of a specific kind (`motion`, `ding`, `on_demand`, `alarm`). |
+| `-D` / `--detection-type` | Only events whose Ring CV classification matches (e.g. `human`, `vehicle`, `animal`, `package`). |
+
+Notes on detection filters:
+
+- Ring populates `cv_properties` only for events evaluated by its computer vision. Older events, `on_demand` (live view) events, and events from devices without CV may not include this data and will be excluded when `--person` or `--detection-type` is used.
+- `--person` is equivalent to `--detection-type human` (but also matches legacy events that only set `person_detected=true` without a detection type).
+- Events without a ready recording (e.g. live-view-only events or recordings still processing) are always skipped — previously these would fail at download time.
+
+### Examples
+
+Download every video from the last 24 hours where a person was detected:
+
+```
+RingVideos all --person -s "yesterday" --path D:\RingVideos
+```
+
+Download only doorbell-button presses (not motion events) from a specific device:
+
+```
+RingVideos all -k ding --id 123456789 --path D:\RingVideos
+```
+
+Download starred clips where Ring classified the detection as a vehicle:
+
+```
+RingVideos starred --detection-type vehicle --path D:\RingVideos
+```
+
+## Version history
+
+- Version 3.2: Added event-kind and detection-type filters (`--kind`, `--detection-type`, `--person`). Events without a ready recording are now skipped automatically.
 - Version 3.0: Added additional download threading and retry options and (hopefully) better download status reporting in the console.
 - Version 2.0: Updated calling syntax to use sub-commands vs flags. Can now also create and download a current snapshot
 - Version 1.3: Updated to leverage the KoenZomers.Ring.Api Nuget package to interact with the Ring API

--- a/RingVideos/CommandHelper.cs
+++ b/RingVideos/CommandHelper.cs
@@ -24,6 +24,9 @@ namespace RingVideos
          var userNameOption = new Option<string>("--username", "-u") { Description = "Ring account username" };
          var maxcountOption = new Option<int>("--maxcount", "-m") { Description = "Maximum number of videos to download", DefaultValueFactory = _ => 1000 };
          var deviceIdOption = new Option<long>("--device-id", "--id") { Description = "Device ID to download videos from. (Use command `devices` to get the available list)" };
+         var personOption = new Option<bool>("--person", "-P") { Description = "Only download videos where a person was detected (shortcut for --detection-type human)" };
+         var kindOption = new Option<string>("--kind", "-k") { Description = "Only download events of this kind. Valid values: motion, ding, on_demand, alarm" };
+         var detectionTypeOption = new Option<string>("--detection-type", "-D") { Description = "Only download events where Ring CV classified the detection as this type. Common values: human, vehicle, animal, package, other_motion" };
          var exitAppOption = new Option<bool>("-x", "--exit") { Description = "Option to close app after running command (vs. keeping open). This could be useful in using in automated scripting." };
 
          RootCommand rootCommand = new RootCommand(description: "Simple command line tool to download videos from your Ring account");
@@ -38,7 +41,10 @@ namespace RingVideos
                parseResult.GetValue(startOption),
                parseResult.GetValue(endOption),
                parseResult.GetValue(maxcountOption),
-               GetNullableLong(parseResult, deviceIdOption));
+               GetNullableLong(parseResult, deviceIdOption),
+               parseResult.GetValue(personOption),
+               parseResult.GetValue(kindOption),
+               parseResult.GetValue(detectionTypeOption));
          });
 
          var allCommand = new Command("all", "Download all videos (starred and unstarred)");
@@ -51,7 +57,10 @@ namespace RingVideos
                parseResult.GetValue(startOption),
                parseResult.GetValue(endOption),
                parseResult.GetValue(maxcountOption),
-               GetNullableLong(parseResult, deviceIdOption));
+               GetNullableLong(parseResult, deviceIdOption),
+               parseResult.GetValue(personOption),
+               parseResult.GetValue(kindOption),
+               parseResult.GetValue(detectionTypeOption));
          });
 
          var snapshotCommand = new Command("snapshot", "Download only snapshot images");
@@ -104,6 +113,9 @@ namespace RingVideos
          starCommand.Add(endOption);
          starCommand.Add(maxcountOption);
          starCommand.Add(deviceIdOption);
+         starCommand.Add(personOption);
+         starCommand.Add(kindOption);
+         starCommand.Add(detectionTypeOption);
          starCommand.Add(exitAppOption);
 
          allCommand.Add(userNameOption);
@@ -113,6 +125,9 @@ namespace RingVideos
          allCommand.Add(endOption);
          allCommand.Add(maxcountOption);
          allCommand.Add(deviceIdOption);
+         allCommand.Add(personOption);
+         allCommand.Add(kindOption);
+         allCommand.Add(detectionTypeOption);
          allCommand.Add(exitAppOption);
 
          snapshotCommand.Add(userNameOption);

--- a/RingVideos/Models/Authentication.cs
+++ b/RingVideos/Models/Authentication.cs
@@ -30,11 +30,14 @@ namespace RingVideos.Models
             {
                 using (Aes myAes = Aes.Create())
                 {
-#pragma warning disable SYSLIB0041 // Type or member is obsolete
-               var derived =  new Rfc2898DeriveBytes(Encoding.ASCII.GetBytes(this.Key), Encoding.ASCII.GetBytes(this.salt), 100);
-#pragma warning restore SYSLIB0041 // Type or member is obsolete
-               myAes.GenerateIV();
-                    myAes.Key = derived.GetBytes(32);
+                    var derivedKey = Rfc2898DeriveBytes.Pbkdf2(
+                        Encoding.ASCII.GetBytes(this.Key),
+                        Encoding.ASCII.GetBytes(this.salt),
+                        100,
+                        HashAlgorithmName.SHA1,
+                        32);
+                    myAes.GenerateIV();
+                    myAes.Key = derivedKey;
                     this.EncryptionIV =  Convert.ToBase64String(myAes.IV);
 
                     ICryptoTransform encryptor = myAes.CreateEncryptor(myAes.Key, myAes.IV);
@@ -90,10 +93,13 @@ namespace RingVideos.Models
                     {
                         myAes.IV = Convert.FromBase64String(this.EncryptionIV);
                     }
-#pragma warning disable SYSLIB0041 // Type or member is obsolete
-               var derived = new Rfc2898DeriveBytes(Encoding.ASCII.GetBytes(this.Key), Encoding.ASCII.GetBytes(this.salt), 100);
-#pragma warning restore SYSLIB0041 // Type or member is obsolete
-               myAes.Key = derived.GetBytes(32);
+                    var derivedKey = Rfc2898DeriveBytes.Pbkdf2(
+                        Encoding.ASCII.GetBytes(this.Key),
+                        Encoding.ASCII.GetBytes(this.salt),
+                        100,
+                        HashAlgorithmName.SHA1,
+                        32);
+                    myAes.Key = derivedKey;
                     // Create a decryptor to perform the stream transform.
                     ICryptoTransform decryptor = myAes.CreateDecryptor(myAes.Key, myAes.IV);
                     var passwordBytes = Convert.FromBase64String(this.Password);

--- a/RingVideos/Models/Filter.cs
+++ b/RingVideos/Models/Filter.cs
@@ -10,7 +10,6 @@ namespace RingVideos.Models
       public DateTime? StartDateTime { get; set; }
       public DateTime? EndDateTime { get; set; } = DateTime.Today.AddDays(1).AddSeconds(-1);
 
-      private DateTime? _startDateTimeUtc = null;
       [JsonIgnore]
       public DateTime? StartDateTimeUtc
       {
@@ -46,6 +45,18 @@ namespace RingVideos.Models
       public string TimeZone { get; set; }
       [JsonIgnore]
       public bool OnlyStarred { get; set; } = false;
+      [JsonIgnore]
+      public bool OnlyPersonDetected { get; set; } = false;
+      /// <summary>
+      /// When set, only download events of this kind (e.g. "motion", "ding", "on_demand", "alarm").
+      /// </summary>
+      [JsonIgnore]
+      public string Kind { get; set; }
+      /// <summary>
+      /// When set, only download events whose Ring CV detection_type matches (e.g. "human", "vehicle", "animal", "package", "other_motion").
+      /// </summary>
+      [JsonIgnore]
+      public string DetectionType { get; set; }
       public bool SetDebug { get; set; } = false;
       [JsonIgnore]
       public bool Snapshots { get; set; } = false;

--- a/RingVideos/Program.cs
+++ b/RingVideos/Program.cs
@@ -1,13 +1,12 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Console;
 using RingVideos.Models;
 using System;
 using System.IO;
 using System.Linq;
 using Serilog;
+using Serilog.Events;
 using RingVideos.Writers;
 
 namespace RingVideos
@@ -19,18 +18,9 @@ namespace RingVideos
       private static IConfigurationRoot Configuration;
       public static void Main(string[] args)
       {
-
-         var level = LogLevel.Information;
-
-         if (args.Any(a => a.ToLower().EndsWith("-d") || a.ToLower().EndsWith("-debug")))
-         {
-            level = LogLevel.Debug;
-         }
-         else if (args.Any(a => a.ToLower().EndsWith("-t") || a.ToLower().EndsWith("-trace")))
-         {
-            level = LogLevel.Trace;
-         }
-
+         // Extract and strip verbosity flags (-d / --debug / -t / --trace) before
+         // they are handed off to System.CommandLine, which doesn't know about them.
+         var (filteredArgs, minimumLevel) = ExtractVerbosityFlags(args);
 
          Configuration = new ConfigurationBuilder()
           .AddJsonFile(configFileName, optional: true, reloadOnChange: true)
@@ -38,15 +28,21 @@ namespace RingVideos
           .Build();
 
          // Configure Serilog
-         Log.Logger = new LoggerConfiguration()
+         var loggerConfig = new LoggerConfiguration()
              .ReadFrom.Configuration(Configuration)
-             .WriteTo.File(logFileBaseName, rollingInterval: RollingInterval.Day)
-             .CreateLogger();
+             .WriteTo.File(logFileBaseName, rollingInterval: RollingInterval.Day);
+
+         if (minimumLevel.HasValue)
+         {
+            loggerConfig = loggerConfig.MinimumLevel.Is(minimumLevel.Value);
+         }
+
+         Log.Logger = loggerConfig.CreateLogger();
 
          try
          {
             Log.Information("Starting up");
-            CreateHostBuilder(args).Build().Run();
+            CreateHostBuilder(filteredArgs).Build().Run();
          }
          catch (Exception ex)
          {
@@ -57,6 +53,28 @@ namespace RingVideos
             Log.CloseAndFlush();
          }
       }
+
+      private static (string[] args, LogEventLevel? level) ExtractVerbosityFlags(string[] args)
+      {
+         LogEventLevel? level = null;
+         var filtered = args.Where(a =>
+         {
+            var lower = a.ToLowerInvariant();
+            if (lower == "-d" || lower == "--debug")
+            {
+               level = LogEventLevel.Debug;
+               return false;
+            }
+            if (lower == "-t" || lower == "--trace")
+            {
+               level = LogEventLevel.Verbose;
+               return false;
+            }
+            return true;
+         }).ToArray();
+         return (filtered, level);
+      }
+
       public static IHostBuilder CreateHostBuilder(string[] args)
       {
 
@@ -85,5 +103,6 @@ namespace RingVideos
       public string[] Args { get; set; } = args;
    }
 }
+
 
 

--- a/RingVideos/RingVideoApplication.cs
+++ b/RingVideos/RingVideoApplication.cs
@@ -46,7 +46,7 @@ namespace RingVideos
          {
             ReadSettings();
          }
-         catch(Exception exe)
+         catch(Exception)
          {
             cw.Warning("Failed to load saved settings");
          }
@@ -62,7 +62,7 @@ namespace RingVideos
             this.Auth = settings.Authentication.Decrypt();
             this.Filter = settings.Filter;
          }
-         catch(Exception exe)
+         catch(Exception)
          {
             var tmpAuth = config.GetSection("Authentication").Get<Authentication>();
             if (tmpAuth != null)
@@ -137,6 +137,15 @@ namespace RingVideos
                message.AppendLine($"Max downloads:\t{Filter.VideoCount}");
             }
             message.AppendLine($"Only Starred:\t{Filter.OnlyStarred}");
+            message.AppendLine($"Only Person:\t{Filter.OnlyPersonDetected}");
+            if (!string.IsNullOrWhiteSpace(Filter.Kind))
+            {
+               message.AppendLine($"Event Kind:\t{Filter.Kind}");
+            }
+            if (!string.IsNullOrWhiteSpace(Filter.DetectionType))
+            {
+               message.AppendLine($"Detection:\t{Filter.DetectionType}");
+            }
             message.AppendLine($"Snapshots:\t{Filter.Snapshots}");
             if (!string.IsNullOrWhiteSpace(expandedPath))
             {
@@ -168,7 +177,7 @@ namespace RingVideos
                       Thread.Sleep(500);
                    });
             }
-            catch(Exception exe)
+            catch(Exception)
             {
                cw.Error("Failed to authenticate with refresh token");
             }
@@ -300,6 +309,28 @@ namespace RingVideos
                {
                   dings = dings.Where(d => d.Favorite == true).ToList();
                }
+               if (Filter.OnlyPersonDetected)
+               {
+                  dings = dings.Where(d => d.CvProperties != null &&
+                                           (d.CvProperties.PersonDetected == true ||
+                                            string.Equals(d.CvProperties.DetectionType, "human", StringComparison.OrdinalIgnoreCase))).ToList();
+               }
+               if (!string.IsNullOrWhiteSpace(Filter.DetectionType))
+               {
+                  var detType = Filter.DetectionType.Trim();
+                  dings = dings.Where(d => d.CvProperties != null &&
+                                           (string.Equals(d.CvProperties.DetectionType, detType, StringComparison.OrdinalIgnoreCase) ||
+                                            (string.Equals(detType, "human", StringComparison.OrdinalIgnoreCase) && d.CvProperties.PersonDetected == true))).ToList();
+               }
+               if (!string.IsNullOrWhiteSpace(Filter.Kind))
+               {
+                  var kind = Filter.Kind.Trim();
+                  dings = dings.Where(d => string.Equals(d.Kind, kind, StringComparison.OrdinalIgnoreCase)).ToList();
+               }
+               // Skip events that do not have a ready recording — snapshot/live-view events and
+               // in-progress recordings would otherwise fail when attempting to download.
+               dings = dings.Where(d => d.Recording != null &&
+                                        string.Equals(d.Recording.Status, "ready", StringComparison.OrdinalIgnoreCase)).ToList();
                dings = dings.OrderBy(d => d.CreatedAtDateTime).ToList();
                string limitmessage = "";
                if(dings.Count() > Filter.VideoCount)

--- a/RingVideos/RingVideos.csproj
+++ b/RingVideos/RingVideos.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <Version>3.0.0</Version>
+    <TargetFramework>net10.0</TargetFramework>
+    <Version>3.2.0</Version>
     <Authors>MIchael McKechney</Authors>
     <Company>blueskydev.us</Company>
     <Description>Bulk downloader for Ring.com videos.</Description>

--- a/RingVideos/Worker.cs
+++ b/RingVideos/Worker.cs
@@ -30,6 +30,7 @@ namespace RingVideos
       private static RootCommand rootCommand;
       private static ConsoleWriter cw;
       private static IHostApplicationLifetime appLifetime;
+      private static bool quitRequested = false;
 
       public Worker(ILogger<Worker> log, IConfiguration config, RingVideoApplication ringApp,  StartArgs sArgs, CommandHelper cmdHelper, ConsoleWriter  consoleWriter, IHostApplicationLifetime appLifetime)
       {
@@ -48,52 +49,57 @@ namespace RingVideos
          try
          {
             rootCommand = cmdHelper.SetupCommands();
-            bool showFilter = false;
             if (Worker.sArgs.Args.Length == 0)
             {
                Worker.sArgs.Args = new string[] { "-h" };
-               showFilter = true;
             }
 
             int val = await rootCommand.Parse(Worker.sArgs.Args).InvokeAsync();
-            //if (showFilter)
-            //{
-            //   ringApp.FilterMessage("Saved filter settings (use command flags to override):");
-            //}
             if (Worker.sArgs.Args.Contains("-x") || Worker.sArgs.Args.Contains("--exit"))
             {
                appLifetime.StopApplication();
                return;
             }
-            showFilter = false;
             while (true)
             {
+               if (quitRequested || stoppingToken.IsCancellationRequested)
+               {
+                  break;
+               }
                ringApp.FilterMessage("Saved filter settings (use command flags to override):");
                Console.ForegroundColor = ConsoleColor.White;
                Console.WriteLine();
                Console.Write("RingVideos> ");
                var line = Console.ReadLine();
 
+               if (line == null)
+               {
+                  // stdin closed (e.g. Ctrl+Z / piped input ended) — exit gracefully
+                  break;
+               }
+
                if (line.Length == 0)
                {
                   line = "-h";
-                  showFilter = true;
                }
 
                try
                {
                   val = await rootCommand.Parse(line).InvokeAsync();
-                  //if (showFilter)
-                  //{
-                  //   ringApp.FilterMessage("Saved filter settings (use command flags to override):");
-                  //}
                }
                catch (Exception exe)
                {
                   if (exe.Message != "Nullable object must have a value.") 
                      log.LogError($"❌ Failed to run command: {exe.Message}");
                }
+
+               if (quitRequested)
+               {
+                  break;
+               }
             }
+
+            appLifetime.StopApplication();
      
          }
          catch(Exception exe)
@@ -107,21 +113,21 @@ namespace RingVideos
 
       public static async Task<int> GetSnapshotImages(string username, string password, string path, DateTime start, DateTime end, long? deviceId)
       {
-         return await GetVideos(username, password, path, start, end, false, true, 1000, deviceId);
+         return await GetVideos(username, password, path, start, end, false, false, null, null, true, 1000, deviceId);
       }
 
-      public static async Task<int> GetAllVideos(string username, string password, string path, DateTime start, DateTime end, int maxcount, long? deviceId)
+      public static async Task<int> GetAllVideos(string username, string password, string path, DateTime start, DateTime end, int maxcount, long? deviceId, bool personOnly, string kind, string detectionType)
       {
-         return await GetVideos(username, password, path, start, end, false, false, maxcount, deviceId);
+         return await GetVideos(username, password, path, start, end, false, personOnly, kind, detectionType, false, maxcount, deviceId);
       }
-      public static async Task<int> GetStarredVideos(string username, string password, string path, DateTime start, DateTime end, int maxcount, long? deviceId)
+      public static async Task<int> GetStarredVideos(string username, string password, string path, DateTime start, DateTime end, int maxcount, long? deviceId, bool personOnly, string kind, string detectionType)
       {
-         return await GetVideos(username, password, path, start, end, true, false, maxcount, deviceId);
+         return await GetVideos(username, password, path, start, end, true, personOnly, kind, detectionType, false, maxcount, deviceId);
       }
-      private static async Task<int> GetVideos(string username, string password, string path, DateTime start, DateTime end, bool starred, bool snapshot, int maxcount, long? deviceId)
+      private static async Task<int> GetVideos(string username, string password, string path, DateTime start, DateTime end, bool starred, bool personOnly, string kind, string detectionType, bool snapshot, int maxcount, long? deviceId)
       {
 
-         SetFilterAndAuthValues(username, password, path, start, end, starred, snapshot, maxcount, deviceId);
+         SetFilterAndAuthValues(username, password, path, start, end, starred, personOnly, kind, detectionType, snapshot, maxcount, deviceId);
 
          if (SetAuthenticationValues())
          {
@@ -135,7 +141,7 @@ namespace RingVideos
 
       }
      
-      private static void SetFilterAndAuthValues(string username, string password, string path, DateTime start, DateTime end, bool starred, bool snapshot, int maxcount, long? deviceId)
+      private static void SetFilterAndAuthValues(string username, string password, string path, DateTime start, DateTime end, bool starred, bool personOnly, string kind, string detectionType, bool snapshot, int maxcount, long? deviceId)
       {
          if (!string.IsNullOrEmpty(username))
          {
@@ -165,6 +171,9 @@ namespace RingVideos
          }
   
          ringApp.Filter.OnlyStarred = starred;
+         ringApp.Filter.OnlyPersonDetected = personOnly;
+         ringApp.Filter.Kind = string.IsNullOrWhiteSpace(kind) ? null : kind;
+         ringApp.Filter.DetectionType = string.IsNullOrWhiteSpace(detectionType) ? null : detectionType;
          ringApp.Filter.Snapshots = snapshot;
      
          if (maxcount != 0)
@@ -188,6 +197,7 @@ namespace RingVideos
      
       public static void QuitApplication()
       {
+         quitRequested = true;
          appLifetime.StopApplication();
       }
       private static bool SetAuthenticationValues()


### PR DESCRIPTION
New filters (applied to starred and ll commands):
- --person / -P: only download events where Ring CV detected a person
- --detection-type / -D: filter by Ring CV classification (human, vehicle, animal, package, other_motion)
- --kind / -k: filter by event kind (motion, ding, on_demand, alarm)
- Events without a ready recording are now always skipped so they no longer fail at download time.

To support these, DoorbotHistoryEvent gained a new CvProperties entity modeling Ring's cv_properties (person_detected, stream_broken, detection_type), and Filter gained Kind/DetectionType/OnlyPersonDetected.

Framework & build:
- Target framework upgraded from net8.0 to net10.0 (both projects and GitHub Actions workflow).
- Bumped RingVideos version to 3.2.0.

Warning fixes:
- Replaced obsolete Rfc2898DeriveBytes constructor (SYSLIB0060) with the static Rfc2898DeriveBytes.Pbkdf2 API, preserving SHA1 + 100 iterations so existing encrypted credentials on disk remain decryptable.
- Removed unused locals/fields causing CS0168/CS0219/CS0414 warnings (_startDateTimeUtc, showFilter, unused Program.Main level variable, unused exception variables).

Bug fixes:
- quit / xit / q now actually exits the app. The REPL loop was ignoring IHostApplicationLifetime.StopApplication(); it now checks a quitRequested flag (and the stoppingToken) and breaks out cleanly. Closed stdin (Ctrl+Z) also exits gracefully.
- Program.cs now strips -d/--debug and -t/--trace from args before handing them to System.CommandLine (previously caused "-d was not matched" errors) and uses them to raise Serilog's minimum log level.

Docs:
- ReadMe.md updated with a full filter reference table, usage examples, and version history entry for 3.2.